### PR TITLE
Added arguments `root_path` and `queue_config_path` (optional).

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ class TestCase(unittest.TestCase, TestGae3):
 
     def setUp(self):
         super().setUp()
-        TestGae3.set_up(self)  # activate GAE testbed
+
+        # For using queues names other then 'default', root_path dir must contain file
+        # 'queue.yaml' (or 'queue.yml') with correct queues definition.
+        # If root_path set to None, only 'default' queue is available.
+        TestGae3.set_up(self, 'path/to/folder/with/queue.yaml')  # activate GAE testbed
 
     def tearDown(self):
         TestGae3.tear_down(self)  # deactivate GAE testbed

--- a/history.txt
+++ b/history.txt
@@ -1,3 +1,5 @@
++ Added arguments `root_path` and `queue_config_path` (optional) to `set_up` method for using queues names other then 'default' in tests.
+
 21.04.2023 ver.1.1
 ------------------
 

--- a/test_helper_gae3/__init__.py
+++ b/test_helper_gae3/__init__.py
@@ -12,8 +12,16 @@ class TestGae3:
     blobstore_stub = None
     taskqueue_stub = None
 
-    def set_up(self):
-        """Activate GAE testbed for project in given dir."""
+    def set_up(self, root_path, queue_config_path=None):
+        """Activate GAE testbed for project in root_path dir.
+
+        For using queues names other then 'default', root_path dir must contain file 'queue.yaml' (or 'queue.yml')
+        with correct queues definition.
+
+        If root_path set to None, only 'default' queue is available.
+
+        Argument `queue_config_path` can contain the full path to queue.yaml; supersedes root_path.
+        """
         self.gae_testbed = testbed.Testbed()
         self.gae_testbed.activate()
         # self.gae_testbed.setup_env()
@@ -26,7 +34,10 @@ class TestGae3:
         self.gae_testbed.init_images_stub()
         self.gae_testbed.init_mail_stub()
 
-        self.gae_testbed.init_taskqueue_stub()
+        self.gae_testbed.init_taskqueue_stub(
+          root_path=root_path,
+          queue_config_path=queue_config_path
+        )
         self.taskqueue_stub = self.gae_testbed.get_stub(testbed.TASKQUEUE_SERVICE_NAME)
 
         self.gae_testbed.init_urlfetch_stub()

--- a/tests/test/test_init.py
+++ b/tests/test/test_init.py
@@ -15,7 +15,7 @@ class TestInitTestbed(TestCase):
         tester = TestGae3()
         assert tester.gae_testbed is None
 
-        tester.set_up()
+        tester.set_up(None)
         assert tester.gae_testbed is not None
 
         tester.tear_down()

--- a/tests/test/test_services/__init__.py
+++ b/tests/test/test_services/__init__.py
@@ -12,7 +12,7 @@ class TestServices(TestCase):
         from test_helper_gae3 import TestGae3
 
         self.tester = TestGae3()
-        self.tester.set_up()
+        self.tester.set_up(None)
 
     def tearDown(self):
         """Deactivate tester."""


### PR DESCRIPTION
To `set_up` method for using queues names other then 'default' in tests.